### PR TITLE
fix: don't block urls in referer with no port

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 # Contributors to Referer Hardening Plugin
 
+- [Esad Cetiner](https://github.com/esadcetiner)
 - [Jozef Sudolský](https://github.com/azurit)

--- a/plugins/referer-hardening-before.conf
+++ b/plugins/referer-hardening-before.conf
@@ -187,7 +187,7 @@ SecRule TX:referer-hardening-plugin_domain_name "!@rx (?i)^[a-z0-9\-.]+$" \
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:referer-hardening-plugin_port "!@rx ^$" \
+SecRule TX:referer-hardening-plugin_port "!@rx ^(?:\:.*)?$" \
     "id:9524180,\
     phase:2,\
     block,\

--- a/tests/regression/referer-hardening-plugin/9524180.yaml
+++ b/tests/regression/referer-hardening-plugin/9524180.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "azurit"
+  author: "azurit, Esad Cetiner"
   description: "Referer Hardening Plugin"
   enabled: true
   name: 9524180.yaml
@@ -56,3 +56,20 @@ tests:
             version: "HTTP/1.1"
           output:
             log_contains: id "9524180"
+  - test_title: 9524180-4
+    desc: "Don't block URLs with no ports"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Referer: "http://example.com/something"
+            port: 80
+            method: "GET"
+            uri: "/get"
+            version: "HTTP/1.1"
+          output:
+            no_log_contains: id "9524180"


### PR DESCRIPTION
`9524180` assumes that all referers must have a port number, however in most cases they don't have a port number. This PR modifies `9524180` to check for a colon before blocking a request.